### PR TITLE
Close specification-coverage gaps from docs/gap_analysis.md

### DIFF
--- a/docs/use_cases/uc-072-assign-athlete-to-series.md
+++ b/docs/use_cases/uc-072-assign-athlete-to-series.md
@@ -46,7 +46,7 @@
 **Trigger:** Step 4 — more than one category of the series matches the athlete's gender and birth year.
 **Flow:**
 
-1. The category lookup (`fetchOneInto`) throws a `TooManyRowsException`, which is not handled; the assignment fails with an internal error. Category year ranges per gender should not overlap.
+1. The category lookup (`fetchOptionalInto`) throws a `TooManyRowsException`, which is not handled; the assignment fails with an internal error. Category year ranges per gender should not overlap.
 
 ### A4: New athlete
 

--- a/src/main/java/ch/jtaf/configuration/security/SecurityConfiguration.java
+++ b/src/main/java/ch/jtaf/configuration/security/SecurityConfiguration.java
@@ -17,6 +17,11 @@ import org.springframework.security.web.SecurityFilterChain;
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Base64;
 
+/**
+ * Realizes UC-003 (Sign in), Steps 4-5: credential verification through the Spring
+ * Security filter chain with BCrypt and the stateless JWT cookie issued by
+ * {@code VaadinStatelessSecurityConfigurer}.
+ */
 @Configuration
 @EnableWebSecurity
 public class SecurityConfiguration {

--- a/src/main/java/ch/jtaf/domain/AthleteDAO.java
+++ b/src/main/java/ch/jtaf/domain/AthleteDAO.java
@@ -49,6 +49,10 @@ public class AthleteDAO extends JooqDAO<Athlete, AthleteRecord, Long> {
             .fetchInto(ATHLETE);
     }
 
+    /**
+     * UC-072 (Assign athlete to series), Step 2: lists the athletes of the organization
+     * that are not yet enrolled in the series (A2 exclusion).
+     */
     public List<AthleteRecord> findByOrganizationIdAndSeriesId(long organizationId, long seriesId, Condition condition, int offset, int limit) {
         return dslContext
             .selectFrom(ATHLETE)
@@ -79,6 +83,10 @@ public class AthleteDAO extends JooqDAO<Athlete, AthleteRecord, Long> {
             .fetchOptionalInto(Integer.class).orElse(0);
     }
 
+    /**
+     * UC-080/UC-083 (Enter result, Filter athletes for result entry): the athletes of the
+     * competition's series matching the result-entry filter.
+     */
     public Result<Record5<Long, String, String, String, Long>> getAthletes(long competitionId, Condition condition, int offset, int limit) {
         return dslContext
             .select(

--- a/src/main/java/ch/jtaf/domain/CategoryAthleteDAO.java
+++ b/src/main/java/ch/jtaf/domain/CategoryAthleteDAO.java
@@ -29,7 +29,8 @@ public class CategoryAthleteDAO extends JooqDAO<CategoryAthlete, CategoryAthlete
 
     /**
      * Assigns the athlete to the category of the series that matches the athlete's gender
-     * and year of birth.
+     * and year of birth (UC-072/UC-085, BR-044). The {@link #isAssignedToSeries} guard
+     * enforces BR-045: an athlete is enrolled in at most one category per series.
      * @return the id of the matching category, or empty if the series has no category for
      * the athlete (in this case nothing is inserted)
      */

--- a/src/main/java/ch/jtaf/domain/CategoryAthleteId.java
+++ b/src/main/java/ch/jtaf/domain/CategoryAthleteId.java
@@ -1,4 +1,9 @@
 package ch.jtaf.domain;
 
-public record CategoryAthleteId(long categoryId, long athleteId) {
+/**
+ * Composite id of {@code CATEGORY_ATHLETE}. The component order must match the primary
+ * key column order {@code (athlete_id, category_id)} because {@code JooqDAO#findById(ID)}
+ * maps the record components onto the key fields positionally.
+ */
+public record CategoryAthleteId(long athleteId, long categoryId) {
 }

--- a/src/main/java/ch/jtaf/domain/CategoryDAO.java
+++ b/src/main/java/ch/jtaf/domain/CategoryDAO.java
@@ -27,6 +27,11 @@ public class CategoryDAO extends JooqDAO<Category, CategoryRecord, Long> {
             .fetch();
     }
 
+    /**
+     * UC-072 (Assign athlete to series), Step 4 / BR-044: resolves the single category of
+     * the series matching the athlete's gender and year of birth. Overlapping category
+     * year ranges make this throw a {@code TooManyRowsException} (A3).
+     */
     public Optional<Long> findIdBySeriesIdAndGenderAndYearOfBirth(long seriesId, String gender, int yearOfBirth) {
         return dslContext
             .select(CATEGORY.ID)

--- a/src/main/java/ch/jtaf/domain/SeriesRankingService.java
+++ b/src/main/java/ch/jtaf/domain/SeriesRankingService.java
@@ -18,6 +18,12 @@ import static ch.jtaf.db.tables.Series.SERIES;
 import static org.jooq.Records.mapping;
 import static org.jooq.impl.DSL.*;
 
+/**
+ * Realizes UC-091 (Download series ranking) and UC-092 (Download club ranking). The
+ * series-ranking query excludes DNF athletes (BR-059, first half); athletes without a
+ * result in every competition are filtered in
+ * {@code SeriesRankingData.Category#getFilteredAndSortedAthletes} (BR-059, second half).
+ */
 // @formatter:off
 @Service
 public class SeriesRankingService {

--- a/src/main/java/ch/jtaf/domain/UserDetailsServiceImpl.java
+++ b/src/main/java/ch/jtaf/domain/UserDetailsServiceImpl.java
@@ -13,6 +13,10 @@ import static ch.jtaf.db.tables.SecurityGroup.SECURITY_GROUP;
 import static ch.jtaf.db.tables.SecurityUser.SECURITY_USER;
 import static ch.jtaf.db.tables.UserGroup.USER_GROUP;
 
+/**
+ * Realizes UC-003 (Sign in), Step 4: loads the user from {@code SECURITY_USER}.
+ * Unconfirmed users are returned as disabled (A2, BR-005).
+ */
 // @formatter:off
 @Service
 @Primary

--- a/src/main/java/ch/jtaf/domain/data/SeriesRankingData.java
+++ b/src/main/java/ch/jtaf/domain/data/SeriesRankingData.java
@@ -11,6 +11,10 @@ public record SeriesRankingData(String name, int numberOfCompetitions, List<Cate
 
 	public record Category(String abbreviation, String name, int yearFrom, int yearTo, List<Athlete> athletes) {
 
+		/**
+		 * UC-091, BR-059: only athletes with a result in every competition of the series
+		 * appear in the ranking, ordered by total points.
+		 */
 		public List<Athlete> getFilteredAndSortedAthletes(int numberOfCompetitions) {
 			return athletes.stream()
 				.filter(athlete -> athlete.results != null && athlete.results().size() == numberOfCompetitions)

--- a/src/main/java/ch/jtaf/domain/report/SeriesRankingReport.java
+++ b/src/main/java/ch/jtaf/domain/report/SeriesRankingReport.java
@@ -14,6 +14,10 @@ import java.util.Locale;
 
 import static org.openpdf.text.PageSize.A4;
 
+/**
+ * UC-091 (Download series ranking), Step 4: renders the ranking PDF. Generation errors
+ * are logged and yield an empty byte array (UC-091 failure postcondition).
+ */
 public class SeriesRankingReport extends RankingReport {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SeriesRankingReport.class);

--- a/src/main/java/ch/jtaf/ui/DashboardView.java
+++ b/src/main/java/ch/jtaf/ui/DashboardView.java
@@ -25,6 +25,12 @@ import java.time.format.DateTimeFormatter;
 
 import static ch.jtaf.ui.util.LogoUtil.resizeLogo;
 
+/**
+ * Realizes UC-090 (View dashboard) and the public report downloads UC-091 (series
+ * ranking), UC-092 (club ranking) and UC-093 (competition ranking); signed-in users
+ * additionally get UC-094 (diplomas), UC-095 (event ranking) and the entry points to
+ * UC-080 and UC-100.
+ */
 @AnonymousAllowed
 @Route(value = "")
 public class DashboardView extends VerticalLayout implements HasDynamicTitle {

--- a/src/main/java/ch/jtaf/ui/LoginView.java
+++ b/src/main/java/ch/jtaf/ui/LoginView.java
@@ -8,6 +8,10 @@ import com.vaadin.flow.router.*;
 
 import java.io.Serial;
 
+/**
+ * Realizes UC-003 (Sign in): the login overlay (Steps 1-3), the localized error state for
+ * {@code ?error} (A1) and the forward of already signed-in visitors (A3).
+ */
 @Route
 @PageTitle("JTAF - Login")
 public class LoginView extends LoginOverlay implements AfterNavigationObserver, BeforeEnterObserver {

--- a/src/main/java/ch/jtaf/ui/MainLayout.java
+++ b/src/main/java/ch/jtaf/ui/MainLayout.java
@@ -240,6 +240,10 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver, Be
 		version.setText(applicationVersion);
 	}
 
+	/**
+	 * UC-003 (Sign in), Step 6: reveals the protected navigation links, the username and
+	 * the logout button for signed-in users; hides them again for visitors (UC-004).
+	 */
 	@SuppressWarnings("java:S3776")
 	@Override
 	public void beforeEnter(BeforeEnterEvent event) {

--- a/src/main/java/ch/jtaf/ui/ResultCapturingView.java
+++ b/src/main/java/ch/jtaf/ui/ResultCapturingView.java
@@ -50,6 +50,11 @@ import static ch.jtaf.db.tables.Competition.COMPETITION;
 import static ch.jtaf.db.tables.Result.RESULT;
 import static org.jooq.impl.DSL.upper;
 
+/**
+ * Realizes UC-080 (Enter result) with the athlete filter of UC-083, the DNF toggle of
+ * UC-081, the result removal of UC-082 and the athlete assignment/correction of
+ * UC-085/UC-086.
+ */
 @RolesAllowed({ Role.USER, Role.ADMIN })
 @Route
 public class ResultCapturingView extends VerticalLayout implements HasDynamicTitle, HasUrlParameter<String> {
@@ -324,7 +329,7 @@ public class ResultCapturingView extends VerticalLayout implements HasDynamicTit
 			});
 
 			categoryAthleteDAO
-				.findById(new CategoryAthleteId(event.getValue().get(CATEGORY.ID), event.getValue().get(ATHLETE.ID)))
+				.findById(new CategoryAthleteId(event.getValue().get(ATHLETE.ID), event.getValue().get(CATEGORY.ID)))
 				.ifPresent(categoryAthleteRecord -> dnf.setValue(categoryAthleteRecord.getDnf()));
 
 			form.add(dnf);

--- a/src/main/java/ch/jtaf/ui/SeriesView.java
+++ b/src/main/java/ch/jtaf/ui/SeriesView.java
@@ -427,6 +427,10 @@ public class SeriesView extends ProtectedView implements HasUrlParameter<Long> {
 		return categoriesSheet;
 	}
 
+	/**
+	 * UC-072 (Assign athlete to series), Step 1, and UC-074 (Import athletes from Excel):
+	 * the athletes grid with its assign, import and remove actions.
+	 */
 	private void createAthletesSection() {
 		athletesGrid = new Grid<>();
 		athletesGrid.setId("athletes-grid");
@@ -501,6 +505,11 @@ public class SeriesView extends ProtectedView implements HasUrlParameter<Long> {
 		}).setTextAlign(ColumnTextAlign.END).setHeader(athleteActions).setAutoWidth(true).setKey("remove-column");
 	}
 
+	/**
+	 * UC-072 (Assign athlete to series), Steps 4-6: enrols the selected athlete into the
+	 * automatically resolved category, or shows the "No matching category" notification
+	 * (A1).
+	 */
 	private void onAthleteSelect(SearchAthleteDialog.AthleteSelectedEvent athleteSelectedEvent) {
 		var athleteRecord = athleteSelectedEvent.getAthleteRecord();
 		if (seriesRecord != null
@@ -511,6 +520,10 @@ public class SeriesView extends ProtectedView implements HasUrlParameter<Long> {
 		refreshAll();
 	}
 
+	/**
+	 * UC-073 (Remove athlete from series): deletes the athlete's enrolment in this
+	 * series.
+	 */
 	private void removeAthleteFromSeries(UpdatableRecord<?> updatableRecord) {
 		var athleteRecord = (AthleteRecord) updatableRecord;
 		if (seriesRecord != null) {

--- a/src/main/java/ch/jtaf/ui/dialog/SearchAthleteDialog.java
+++ b/src/main/java/ch/jtaf/ui/dialog/SearchAthleteDialog.java
@@ -31,6 +31,12 @@ import static ch.jtaf.db.tables.Athlete.ATHLETE;
 import static ch.jtaf.ui.component.GridBuilder.addActionColumnAndSetSelectionListener;
 import static org.jooq.impl.DSL.lower;
 
+/**
+ * Realizes UC-072 (Assign athlete to series) and UC-085 (Assign athlete during result
+ * entry), Steps 2-3: the search grid is empty until a filter is typed, lists only
+ * athletes not yet enrolled in the series (A2) and allows creating a new athlete that is
+ * assigned right away (A4).
+ */
 public class SearchAthleteDialog extends Dialog {
 
 	@Serial

--- a/src/main/java/ch/jtaf/usecase/UseCase.java
+++ b/src/main/java/ch/jtaf/usecase/UseCase.java
@@ -1,0 +1,25 @@
+package ch.jtaf.usecase;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Links a test method to the use case specification it verifies
+ * ({@code docs/use_cases/uc-xxx-*.md}). The {@code scenario} and {@code businessRules}
+ * values must match the headings in the specification.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface UseCase {
+
+	String id();
+
+	String scenario() default "Main Success Scenario";
+
+	String[] businessRules() default {};
+
+}

--- a/src/test/java/ch/jtaf/domain/SeriesRankingServiceTest.java
+++ b/src/test/java/ch/jtaf/domain/SeriesRankingServiceTest.java
@@ -1,6 +1,7 @@
 package ch.jtaf.domain;
 
 import ch.jtaf.TestcontainersConfiguration;
+import ch.jtaf.usecase.UseCase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,6 +13,10 @@ import java.util.Locale;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Service-level tests for UC-091 (Download series ranking) and UC-092 (Download club
+ * ranking).
+ */
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class SeriesRankingServiceTest {
@@ -24,6 +29,7 @@ class SeriesRankingServiceTest {
 	private SeriesRankingService seriesRankingService;
 
 	@Test
+	@UseCase(id = "UC-092")
 	void get_club_ranking() {
 		var clubRanking = seriesRankingService.getClubRanking(1L);
 
@@ -32,6 +38,7 @@ class SeriesRankingServiceTest {
 	}
 
 	@Test
+	@UseCase(id = "UC-092")
 	void create_club_ranking_pdf() {
 		byte[] pdf = seriesRankingService.getClubRankingAsPdf(1L, Locale.of("de", "CH"));
 
@@ -39,6 +46,7 @@ class SeriesRankingServiceTest {
 	}
 
 	@Test
+	@UseCase(id = "UC-091")
 	void get_series_ranking() {
 		var seriesRanking = seriesRankingService.getSeriesRanking(3L);
 
@@ -47,6 +55,7 @@ class SeriesRankingServiceTest {
 	}
 
 	@Test
+	@UseCase(id = "UC-091")
 	void create_series_ranking_pdf() {
 		byte[] pdf = seriesRankingService.getSeriesRankingAsPdf(3L, Locale.of("de", "CH"));
 

--- a/src/test/java/ch/jtaf/domain/UserDetailsServiceImplTest.java
+++ b/src/test/java/ch/jtaf/domain/UserDetailsServiceImplTest.java
@@ -1,6 +1,7 @@
 package ch.jtaf.domain;
 
 import ch.jtaf.TestcontainersConfiguration;
+import ch.jtaf.usecase.UseCase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,6 +14,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+/**
+ * Service-level tests for UC-003 (Sign in), Step 4 and BR-005.
+ */
 @Import(TestcontainersConfiguration.class)
 @SpringBootTest
 class UserDetailsServiceImplTest {
@@ -28,6 +32,7 @@ class UserDetailsServiceImplTest {
 	private UserService userService;
 
 	@Test
+	@UseCase(id = "UC-003")
 	void load_user_by_username() {
 		UserDetails userDetails = userDetailsService.loadUserByUsername("simon@martinelli.ch");
 
@@ -36,6 +41,7 @@ class UserDetailsServiceImplTest {
 	}
 
 	@Test
+	@UseCase(id = "UC-003", scenario = "A2: Account not confirmed", businessRules = "BR-005")
 	void unconfirmed_user_is_disabled() throws UserAlreadyExistException {
 		userService.createUser("Ursula", "Unbestaetigt", "ursula.unbestaetigt@nodomain.xyz", "pass",
 				java.util.Locale.GERMAN);
@@ -46,6 +52,7 @@ class UserDetailsServiceImplTest {
 	}
 
 	@Test
+	@UseCase(id = "UC-003", scenario = "A1: Invalid credentials")
 	void load_unknown_user() {
 		assertThatExceptionOfType(UsernameNotFoundException.class)
 			.isThrownBy(() -> userDetailsService.loadUserByUsername("jane@doe.com"));

--- a/src/test/java/ch/jtaf/ui/usecase/account/UC003SignInAuthenticationTest.java
+++ b/src/test/java/ch/jtaf/ui/usecase/account/UC003SignInAuthenticationTest.java
@@ -1,0 +1,119 @@
+package ch.jtaf.ui.usecase.account;
+
+import ch.jtaf.TestcontainersConfiguration;
+import ch.jtaf.domain.UserService;
+import ch.jtaf.usecase.UseCase;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Locale;
+
+import static ch.jtaf.db.tables.SecurityUser.SECURITY_USER;
+import static ch.jtaf.db.tables.UserGroup.USER_GROUP;
+import static org.jooq.impl.DSL.select;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+
+/**
+ * UC-003: Sign in — server-side authentication through the real Spring Security filter
+ * chain: credential verification against {@code SECURITY_USER} with BCrypt, the stateless
+ * JWT cookie, and the redirect behaviour. The browserless UI half lives in
+ * {@link UC003SignInTest}.
+ * <p>
+ * See {@code docs/use_cases/uc-003-sign-in.md}.
+ */
+@Import(TestcontainersConfiguration.class)
+@SpringBootTest
+class UC003SignInAuthenticationTest {
+
+	private static final String EMAIL = "uc003.signin@nodomain.xyz";
+
+	private static final String PASSWORD = "s3cret-uc003";
+
+	@SuppressWarnings("unused")
+	@MockitoBean
+	private JavaMailSender javaMailSender;
+
+	@Autowired
+	private WebApplicationContext webApplicationContext;
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private DSLContext dslContext;
+
+	private MockMvc mockMvc;
+
+	@BeforeEach
+	void setUpMockMvc() {
+		mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).apply(springSecurity()).build();
+	}
+
+	@AfterEach
+	void removeCreatedUser() {
+		dslContext.deleteFrom(USER_GROUP)
+			.where(USER_GROUP.USER_ID
+				.in(select(SECURITY_USER.ID).from(SECURITY_USER).where(SECURITY_USER.EMAIL.eq(EMAIL))))
+			.execute();
+		dslContext.deleteFrom(SECURITY_USER).where(SECURITY_USER.EMAIL.eq(EMAIL)).execute();
+	}
+
+	@Test
+	@UseCase(id = "UC-003")
+	void valid_credentials_issue_jwt_cookie_and_forward_to_dashboard() throws Exception {
+		var user = userService.createUser("Ulla", "UseCase", EMAIL, PASSWORD, Locale.ENGLISH);
+		userService.confirm(user.getConfirmationId());
+
+		mockMvc.perform(formLogin("/login").user(EMAIL).password(PASSWORD))
+			.andExpect(authenticated().withUsername(EMAIL))
+			.andExpect(redirectedUrl("/"))
+			.andExpect(cookie().exists("jwt.headerAndPayload"))
+			.andExpect(cookie().exists("jwt.signature"));
+	}
+
+	@Test
+	@UseCase(id = "UC-003", scenario = "A1: Invalid credentials")
+	void wrong_password_reloads_the_login_view_with_error() throws Exception {
+		var user = userService.createUser("Ulla", "UseCase", EMAIL, PASSWORD, Locale.ENGLISH);
+		userService.confirm(user.getConfirmationId());
+
+		mockMvc.perform(formLogin("/login").user(EMAIL).password("wrong"))
+			.andExpect(unauthenticated())
+			.andExpect(redirectedUrl("/login?error"))
+			.andExpect(cookie().doesNotExist("jwt.headerAndPayload"));
+	}
+
+	@Test
+	@UseCase(id = "UC-003", scenario = "A1: Invalid credentials")
+	void unknown_user_reloads_the_login_view_with_error() throws Exception {
+		mockMvc.perform(formLogin("/login").user("not.existing@user.com").password("pass"))
+			.andExpect(unauthenticated())
+			.andExpect(redirectedUrl("/login?error"));
+	}
+
+	@Test
+	@UseCase(id = "UC-003", scenario = "A2: Account not confirmed", businessRules = "BR-005")
+	void unconfirmed_user_is_rejected() throws Exception {
+		userService.createUser("Ulla", "UseCase", EMAIL, PASSWORD, Locale.ENGLISH);
+
+		mockMvc.perform(formLogin("/login").user(EMAIL).password(PASSWORD))
+			.andExpect(unauthenticated())
+			.andExpect(redirectedUrl("/login?error"));
+	}
+
+}

--- a/src/test/java/ch/jtaf/ui/usecase/account/UC003SignInTest.java
+++ b/src/test/java/ch/jtaf/ui/usecase/account/UC003SignInTest.java
@@ -1,12 +1,19 @@
 package ch.jtaf.ui.usecase.account;
 
 import ch.jtaf.configuration.security.Role;
+import ch.jtaf.configuration.security.SecurityContext;
 import ch.jtaf.ui.AbstractViewTest;
 import ch.jtaf.ui.LoginView;
+import ch.jtaf.ui.OrganizationsView;
+import ch.jtaf.usecase.UseCase;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.login.LoginOverlay;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.RouterLink;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
@@ -15,12 +22,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * UC-003: Sign in.
  * <p>
+ * The browserless submit never reaches the Spring Security filter chain; the server-side
+ * authentication (credential verification, JWT cookie, redirect) is covered by
+ * {@link UC003SignInAuthenticationTest}.
+ * <p>
  * See {@code docs/use_cases/uc-003-sign-in.md}.
  */
 class UC003SignInTest extends AbstractViewTest {
 
+	@Autowired
+	private SecurityContext securityContext;
+
 	@Test
-	void login_with_unknown_user() {
+	@UseCase(id = "UC-003")
+	void login_overlay_shows_email_and_password_fields() {
+		setupVaadin();
+
+		navigate(LoginView.class);
+
+		LoginOverlay loginOverlay = find(LoginOverlay.class).single();
+		assertThat(loginOverlay.isOpened()).isTrue();
+
+		// The form labels are configured through the i18n element property
+		String i18n = i18nProperty(loginOverlay);
+		assertThat(i18n).contains("\"username\":\"Email\"")
+			.contains("\"password\":\"Password\"")
+			.contains("\"submit\":\"Sign in\"");
+	}
+
+	@Test
+	@UseCase(id = "UC-003", scenario = "A1: Invalid credentials")
+	void failed_login_stays_unauthenticated_on_the_overlay() {
 		setupVaadin();
 
 		navigate(LoginView.class);
@@ -34,11 +66,29 @@ class UC003SignInTest extends AbstractViewTest {
 			// From GoogleAnalyticsTracker. Ignore
 		}
 
-		assertThat(find(LoginOverlay.class).single().getElement().getOuterHTML())
-			.isEqualTo("<vaadin-login-overlay></vaadin-login-overlay>");
+		// Post-F-1: no authentication is established
+		assertThat(securityContext.isUserLoggedIn()).isFalse();
+		// Post-F-2: the visitor remains on the login overlay and may retry
+		assertThat(find(LoginOverlay.class).single().isOpened()).isTrue();
 	}
 
 	@Test
+	@UseCase(id = "UC-003", scenario = "A1: Invalid credentials")
+	void error_parameter_shows_localized_authentication_error() {
+		setupVaadin();
+
+		UI.getCurrent().navigate("login", QueryParameters.fromString("error"));
+
+		LoginOverlay loginOverlay = find(LoginOverlay.class).single();
+		assertThat(loginOverlay.isError()).isTrue();
+		assertThat(i18nProperty(loginOverlay)).contains("Incorrect email or password")
+			.contains("Check that you have entered the correct email and password and try again.");
+		// The visitor may retry from the still open overlay
+		assertThat(loginOverlay.isOpened()).isTrue();
+	}
+
+	@Test
+	@UseCase(id = "UC-003", scenario = "A3: Already signed in")
 	void already_logged_in() {
 		login("simon@martinelli.ch", "", List.of(Role.ADMIN));
 
@@ -46,6 +96,66 @@ class UC003SignInTest extends AbstractViewTest {
 
 		H1 h1 = find(H1.class).id("view-title");
 		assertThat(h1.getText()).isEqualTo("Dashboard");
+	}
+
+	@Test
+	@UseCase(id = "UC-003")
+	void drawer_reveals_protected_links_after_sign_in() {
+		login("simon@martinelli.ch", "", List.of(Role.ADMIN));
+
+		assertThat(find(RouterLink.class).id("series-list-link").isVisible()).isTrue();
+		assertThat(visibleRouterLinkTargets()).contains("events", "clubs", "athletes");
+
+		// Post-S-2: the MainLayout shows the username and the logout button
+		Button logout = find(Button.class).id("logout");
+		assertThat(logout.isVisible()).isTrue();
+		assertThat(logout.getText()).isEqualTo("Logout (simon@martinelli.ch)");
+	}
+
+	@Test
+	@UseCase(id = "UC-003")
+	void drawer_hides_protected_links_for_visitors() {
+		setupVaadin();
+
+		// The queries only match visible components: the protected links are hidden
+		assertThat(find(RouterLink.class).withId("series-list-link").all()).isEmpty();
+		assertThat(visibleRouterLinkTargets()).doesNotContain("events", "clubs", "athletes");
+		assertThat(find(Button.class).withId("logout").all()).isEmpty();
+	}
+
+	@Test
+	@UseCase(id = "UC-003", businessRules = "BR-006")
+	void anonymous_visitor_cannot_open_protected_views() {
+		setupVaadin();
+
+		UI.getCurrent().navigate(OrganizationsView.class);
+
+		// The navigation is denied: the visitor never reaches the protected view
+		assertThat(find(H1.class).id("view-title").getText()).isEqualTo("Dashboard");
+		assertThat(securityContext.isUserLoggedIn()).isFalse();
+	}
+
+	@Test
+	@UseCase(id = "UC-003", businessRules = "BR-006")
+	void user_role_may_open_protected_views() {
+		login("simon@martinelli.ch", "", List.of(Role.USER));
+
+		UI.getCurrent().navigate(OrganizationsView.class);
+
+		H1 h1 = find(H1.class).id("view-title");
+		assertThat(h1.getText()).isEqualTo("Organizations");
+	}
+
+	private static String i18nProperty(LoginOverlay loginOverlay) {
+		return String.valueOf(loginOverlay.getElement().getPropertyRaw("i18n"));
+	}
+
+	private List<String> visibleRouterLinkTargets() {
+		return find(RouterLink.class).all()
+			.stream()
+			.filter(com.vaadin.flow.component.Component::isVisible)
+			.map(RouterLink::getHref)
+			.toList();
 	}
 
 }

--- a/src/test/java/ch/jtaf/ui/usecase/athlete/UC072AssignAthleteToSeriesTest.java
+++ b/src/test/java/ch/jtaf/ui/usecase/athlete/UC072AssignAthleteToSeriesTest.java
@@ -3,31 +3,61 @@ package ch.jtaf.ui.usecase.athlete;
 import ch.jtaf.configuration.security.Role;
 import ch.jtaf.db.tables.records.AthleteRecord;
 import ch.jtaf.db.tables.records.SeriesRecord;
+import ch.jtaf.domain.AthleteDAO;
+import ch.jtaf.domain.CategoryAthleteDAO;
+import ch.jtaf.domain.CategoryAthleteId;
+import ch.jtaf.domain.CategoryDAO;
 import ch.jtaf.ui.AbstractViewTest;
+import ch.jtaf.ui.dialog.AthleteDialog;
 import ch.jtaf.ui.dialog.ConfirmDialog;
 import ch.jtaf.ui.dialog.SearchAthleteDialog;
+import ch.jtaf.usecase.UseCase;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.Tabs;
 import com.vaadin.flow.component.textfield.TextField;
+import org.jooq.exception.TooManyRowsException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+import static ch.jtaf.db.tables.Athlete.ATHLETE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * UC-072: Assign athlete to series.
  * <p>
- * Also exercises UC-073 (Remove athlete from series) — the test assigns and then removes
- * the athlete.
+ * Also exercises UC-073 (Remove athlete from series) — the main scenario assigns and then
+ * removes the athlete.
+ * <p>
+ * The series opened by {@link #login()} is "CIS 2019" (series id 3) with 108 enrolled
+ * athletes; the seeded athlete Zimmermann (id 1, F, 2011) is not enrolled in it and
+ * matches its category "L".
  * <p>
  * See {@code docs/use_cases/uc-072-assign-athlete-to-series.md} and
  * {@code docs/use_cases/uc-073-remove-athlete-from-series.md}.
  */
 class UC072AssignAthleteToSeriesTest extends AbstractViewTest {
+
+	private static final long CIS_2019_SERIES_ID = 3L;
+
+	private static final long ZIMMERMANN_ID = 1L;
+
+	@Autowired
+	private AthleteDAO athleteDAO;
+
+	@Autowired
+	private CategoryDAO categoryDAO;
+
+	@Autowired
+	private CategoryAthleteDAO categoryAthleteDAO;
 
 	@BeforeEach
 	void login() {
@@ -40,34 +70,43 @@ class UC072AssignAthleteToSeriesTest extends AbstractViewTest {
 		assertThat(name.getValue()).isEqualTo("CIS 2019");
 	}
 
-	@Test
-	void assign_athelete() {
-		Tabs tabs = find(Tabs.class).single();
-		Tab athletes = find(Tab.class).withText("Athletes").single();
-		tabs.setSelectedTab(athletes);
+	@AfterEach
+	void restoreSeededState() {
+		athleteDAO.findById(ZIMMERMANN_ID)
+			.ifPresent(athlete -> categoryAthleteDAO.deleteCategoryAthlete(athlete, CIS_2019_SERIES_ID));
+		athleteDAO.findAll(ATHLETE.LAST_NAME.eq("Fixturenomatch")).forEach(athlete -> {
+			categoryAthleteDAO.deleteCategoryAthlete(athlete, CIS_2019_SERIES_ID);
+			athleteDAO.delete(athlete);
+		});
+	}
 
-		// Check content of athletes grid
-		Grid<AthleteRecord> athletesGrid = find(Grid.class).id("athletes-grid");
+	@Test
+	@UseCase(id = "UC-072", businessRules = "BR-044")
+	void assign_athlete() {
+		Grid<AthleteRecord> athletesGrid = openAthletesTab();
 		assertThat(test(athletesGrid).size()).isEqualTo(108);
 		assertThat(test(athletesGrid).getRow(0).getLastName()).isEqualTo("Berger");
 
-		// Assign athlete
+		// Step 1: open the search dialog from the grid header
 		gridHeaderButton(athletesGrid, "remove-column", "assign-athlete").click();
 
-		assertThat(find(SearchAthleteDialog.class).all()).hasSize(1);
+		SearchAthleteDialog dialog = find(SearchAthleteDialog.class).single();
+		assertThat(dialog.isOpened()).isTrue();
 
 		// Test maximize and restore
 		Button toggle = find(Button.class).id("toggle");
 		toggle.click();
 		toggle.click();
 
-		test(find(TextField.class).withCaption("Filter").withValue("").single()).setValue("z");
-
+		// Step 2: the search grid is empty until a filter is typed
 		Grid<AthleteRecord> searchAthletesGrid = find(Grid.class).id("search-athletes-grid");
-		assertThat(test(searchAthletesGrid).size()).isEqualTo(1);
+		assertThat(test(searchAthletesGrid).size()).isZero();
 
+		test(find(TextField.class).withCaption("Filter").withValue("").single()).setValue("z");
+		assertThat(test(searchAthletesGrid).size()).isEqualTo(1);
 		assertThat(test(searchAthletesGrid).getRow(0).getLastName()).isEqualTo("Zimmermann");
 
+		// Step 3: assign via the per-row button
 		test(searchAthletesGrid).getCellComponent(0, "edit-column")
 			.getChildren()
 			.filter(Button.class::isInstance)
@@ -75,12 +114,21 @@ class UC072AssignAthleteToSeriesTest extends AbstractViewTest {
 			.map(Button.class::cast)
 			.ifPresent(Button::click);
 
-		// Check if athlete was assigned
+		// Step 6: the dialog is closed and the athletes grid refreshed
+		assertThat(dialog.isOpened()).isFalse();
 		assertThat(test(athletesGrid).size()).isEqualTo(109);
 		int assignedRow = findRowByLastName(athletesGrid, "Zimmermann");
 
-		// Remove the assigned athlete again so the seeded state is restored for other
-		// tests.
+		// Steps 4/5 and BR-044: the category was resolved by gender and birth year and
+		// the CATEGORY_ATHLETE row was stored with dnf defaulting to false
+		Long categoryId = categoryDAO.findIdBySeriesIdAndGenderAndYearOfBirth(CIS_2019_SERIES_ID, "F", 2011)
+			.orElseThrow();
+		var categoryAthlete = categoryAthleteDAO.findById(new CategoryAthleteId(ZIMMERMANN_ID, categoryId))
+			.orElseThrow();
+		assertThat(categoryAthlete.getDnf()).isFalse();
+		assertThat(categoryAthleteDAO.countAthletesBySeriesId(CIS_2019_SERIES_ID)).isEqualTo(109);
+
+		// UC-073: remove the assigned athlete again so the seeded state is restored
 		test(athletesGrid).getCellComponent(assignedRow, "remove-column")
 			.getChildren()
 			.filter(Button.class::isInstance)
@@ -92,8 +140,86 @@ class UC072AssignAthleteToSeriesTest extends AbstractViewTest {
 		assertThat(confirmDialog.isOpened()).isTrue();
 		find(Button.class).id("athlete-delete-confirm-dialog-confirm").click();
 
-		// Check if athlete was removed
 		assertThat(test(athletesGrid).size()).isEqualTo(108);
+		assertThat(categoryAthleteDAO.isAssignedToSeries(ZIMMERMANN_ID, CIS_2019_SERIES_ID)).isFalse();
+	}
+
+	@Test
+	@UseCase(id = "UC-072", scenario = "A1: No matching category")
+	void athlete_without_matching_category_is_not_assigned() {
+		Grid<AthleteRecord> athletesGrid = openAthletesTab();
+		gridHeaderButton(athletesGrid, "remove-column", "assign-athlete").click();
+
+		// A4: create a new athlete from the dialog — CIS 2019 has no category for a
+		// birth year before 1900, so the assignment must fail
+		Grid<AthleteRecord> searchAthletesGrid = find(Grid.class).id("search-athletes-grid");
+		gridHeaderButton(searchAthletesGrid, "edit-column").click();
+		assertThat(find(AthleteDialog.class).all()).hasSize(1);
+
+		test(find(TextField.class).withCaption("Last Name").single()).setValue("Fixturenomatch");
+		test(find(TextField.class).withCaption("First Name").single()).setValue("Nora");
+		test(find(Select.class).withCaption("Gender").single()).selectItem("F");
+		test(find(TextField.class).withCaption("Year").single()).setValue("1899");
+		find(Button.class).id("edit-save").click();
+
+		// A1: notification, and Post-F-1: no enrolment is created
+		assertThat(find(Notification.class).all()).isNotEmpty();
+		List<AthleteRecord> created = athleteDAO.findAll(ATHLETE.LAST_NAME.eq("Fixturenomatch"));
+		assertThat(created).hasSize(1);
+		assertThat(categoryAthleteDAO.isAssignedToSeries(created.getFirst().getId(), CIS_2019_SERIES_ID)).isFalse();
+		assertThat(test(athletesGrid).size()).isEqualTo(108);
+	}
+
+	@Test
+	@UseCase(id = "UC-072", scenario = "A2: Athlete already enrolled")
+	void already_enrolled_athlete_is_excluded_from_the_search() {
+		Grid<AthleteRecord> athletesGrid = openAthletesTab();
+		Long enrolledAthleteId = test(athletesGrid).getRow(0).getId();
+
+		gridHeaderButton(athletesGrid, "remove-column", "assign-athlete").click();
+		Grid<AthleteRecord> searchAthletesGrid = find(Grid.class).id("search-athletes-grid");
+
+		// The enrolled athlete does not appear in the search results
+		test(find(TextField.class).withCaption("Filter").withValue("").single())
+			.setValue(String.valueOf(enrolledAthleteId));
+		assertThat(test(searchAthletesGrid).size()).isZero();
+
+		// while a not yet enrolled athlete does
+		test(find(TextField.class).withCaption("Filter").single()).setValue(String.valueOf(ZIMMERMANN_ID));
+		assertThat(test(searchAthletesGrid).size()).isEqualTo(1);
+	}
+
+	@Test
+	@UseCase(id = "UC-072", scenario = "A3: Overlapping categories")
+	void overlapping_categories_fail_the_assignment() {
+		// Series 8 (seed fixture) has two categories covering the same gender and years
+		AthleteRecord athlete = athleteDAO.findAll(ATHLETE.LAST_NAME.eq("Fixtureoverlap")).getFirst();
+
+		assertThatExceptionOfType(TooManyRowsException.class)
+			.isThrownBy(() -> categoryAthleteDAO.createCategoryAthlete(athlete, 8L));
+		assertThat(categoryAthleteDAO.isAssignedToSeries(athlete.getId(), 8L)).isFalse();
+	}
+
+	@Test
+	@UseCase(id = "UC-072", businessRules = "BR-045")
+	void athlete_is_enrolled_in_at_most_one_category_per_series() {
+		Grid<AthleteRecord> athletesGrid = openAthletesTab();
+		AthleteRecord enrolledAthlete = test(athletesGrid).getRow(0);
+		assertThat(categoryAthleteDAO.isAssignedToSeries(enrolledAthlete.getId(), CIS_2019_SERIES_ID)).isTrue();
+		int countBefore = categoryAthleteDAO.countAthletesBySeriesId(CIS_2019_SERIES_ID);
+
+		// A second enrolment attempt inserts nothing
+		categoryAthleteDAO.createCategoryAthlete(enrolledAthlete, CIS_2019_SERIES_ID);
+
+		assertThat(categoryAthleteDAO.countAthletesBySeriesId(CIS_2019_SERIES_ID)).isEqualTo(countBefore);
+	}
+
+	private Grid<AthleteRecord> openAthletesTab() {
+		Tabs tabs = find(Tabs.class).single();
+		Tab athletes = find(Tab.class).withText("Athletes").single();
+		tabs.setSelectedTab(athletes);
+
+		return find(Grid.class).id("athletes-grid");
 	}
 
 	private int findRowByLastName(Grid<AthleteRecord> athletesGrid, String lastName) {

--- a/src/test/java/ch/jtaf/ui/usecase/report/UC091DownloadSeriesRankingTest.java
+++ b/src/test/java/ch/jtaf/ui/usecase/report/UC091DownloadSeriesRankingTest.java
@@ -1,35 +1,126 @@
 package ch.jtaf.ui.usecase.report;
 
 import ch.jtaf.configuration.security.Role;
+import ch.jtaf.domain.SeriesRankingService;
+import ch.jtaf.domain.report.SeriesRankingReport;
 import ch.jtaf.ui.AbstractViewTest;
 import ch.jtaf.ui.DashboardView;
+import ch.jtaf.usecase.UseCase;
 import com.vaadin.flow.component.html.Anchor;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
 
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * UC-091: Download series ranking.
  * <p>
+ * The dashboard anchor {@code series-ranking-1} belongs to the first listed series
+ * ("Jugendmeisterschaft 2019", id 4). The seed fixtures (hidden series 5-8, see
+ * {@code V9999__Data.sql}) provide the edge cases: series 5 has no competitions, series 6
+ * competitions but no results, series 7 a DNF athlete and an athlete missing a
+ * competition.
+ * <p>
  * See {@code docs/use_cases/uc-091-download-series-ranking.md}.
  */
-@SuppressWarnings("java:S2699")
 class UC091DownloadSeriesRankingTest extends AbstractViewTest {
 
-	@BeforeEach
-	void login() {
+	@Autowired
+	private SeriesRankingService seriesRankingService;
+
+	@Test
+	@UseCase(id = "UC-091")
+	void series_ranking() {
 		login("simon@martinelli.ch", "", List.of(Role.ADMIN));
 		navigate(DashboardView.class);
+
+		Anchor anchor = find(Anchor.class).id("series-ranking-1");
+		// Step 2: the download is targeted to a new browser tab
+		assertThat(anchor.getTarget()).contains("_blank");
+
+		var outputStream = new ByteArrayOutputStream();
+		test(anchor).download(outputStream);
+
+		// Step 5 / Post-S-1: a real PDF is delivered, not an empty byte array
+		assertThat(outputStream.toByteArray()).isNotEmpty();
+		assertThat(new String(outputStream.toByteArray(), 0, 4, StandardCharsets.US_ASCII)).isEqualTo("%PDF");
 	}
 
 	@Test
-	void series_ranking() {
-		assertThatNoException()
-			.isThrownBy(() -> test(find(Anchor.class).id("series-ranking-1")).download(new ByteArrayOutputStream()));
+	@UseCase(id = "UC-091", businessRules = "BR-060")
+	void anonymous_visitor_can_download_series_ranking() {
+		setupVaadin();
+		navigate(DashboardView.class);
+
+		var outputStream = new ByteArrayOutputStream();
+		test(find(Anchor.class).id("series-ranking-1")).download(outputStream);
+
+		assertThat(outputStream.toByteArray()).isNotEmpty();
+		assertThat(new String(outputStream.toByteArray(), 0, 4, StandardCharsets.US_ASCII)).isEqualTo("%PDF");
+	}
+
+	@Test
+	@UseCase(id = "UC-091", businessRules = "BR-059")
+	void ranking_includes_only_dnf_free_athletes_with_a_result_in_every_competition() {
+		var ranking = seriesRankingService.getSeriesRanking(7L).orElseThrow();
+
+		assertThat(ranking.numberOfCompetitions()).isEqualTo(2);
+		var category = ranking.categories().getFirst();
+
+		// The DNF athlete is excluded by the query
+		assertThat(category.athletes()).extracting(a -> a.lastName())
+			.containsExactlyInAnyOrder("Fixturecomplete", "Fixtureincomplete");
+
+		// Only the athlete with a result in every competition appears in the ranking
+		var ranked = category.getFilteredAndSortedAthletes(ranking.numberOfCompetitions());
+		assertThat(ranked).hasSize(1);
+		assertThat(ranked.getFirst().lastName()).isEqualTo("Fixturecomplete");
+		assertThat(ranked.getFirst().totalPoints()).isEqualTo(980);
+	}
+
+	@Test
+	@UseCase(id = "UC-091", scenario = "A1: No data")
+	void series_without_competitions_has_no_ranking() {
+		assertThat(seriesRankingService.getSeriesRanking(5L)).isEmpty();
+		assertThatExceptionOfType(NoSuchElementException.class)
+			.isThrownBy(() -> seriesRankingService.getSeriesRankingAsPdf(5L, Locale.ENGLISH));
+	}
+
+	@Test
+	@UseCase(id = "UC-091", scenario = "A1: No data")
+	void series_with_competitions_but_no_results_yields_pdf_with_empty_tables() {
+		byte[] pdf = seriesRankingService.getSeriesRankingAsPdf(6L, Locale.ENGLISH);
+
+		assertThat(pdf).isNotEmpty();
+		assertThat(new String(pdf, 0, 4, StandardCharsets.US_ASCII)).isEqualTo("%PDF");
+	}
+
+	@Test
+	@UseCase(id = "UC-091", scenario = "Failure Postconditions")
+	void unknown_series_raises_an_error() {
+		assertThatExceptionOfType(NoSuchElementException.class)
+			.isThrownBy(() -> seriesRankingService.getSeriesRankingAsPdf(999L, Locale.ENGLISH));
+	}
+
+	@Test
+	@UseCase(id = "UC-091", scenario = "Failure Postconditions")
+	void pdf_generation_errors_are_swallowed_and_yield_an_empty_download() {
+		var ranking = seriesRankingService.getSeriesRanking(7L).orElseThrow();
+		var report = new SeriesRankingReport(ranking, Locale.ENGLISH);
+		assertThat(report.create()).isNotEmpty();
+
+		// A second create() on the same report fails internally because the document is
+		// already closed; the DocumentException is logged and swallowed and the caller
+		// receives an empty byte array — the 0-byte download of the failure
+		// postcondition
+		assertThat(report.create()).isEmpty();
 	}
 
 }

--- a/src/test/java/ch/jtaf/ui/usecase/result/UC080EnterResultTest.java
+++ b/src/test/java/ch/jtaf/ui/usecase/result/UC080EnterResultTest.java
@@ -1,15 +1,27 @@
 package ch.jtaf.ui.usecase.result;
 
 import ch.jtaf.configuration.security.Role;
+import ch.jtaf.domain.AthleteDAO;
+import ch.jtaf.domain.EventDAO;
+import ch.jtaf.domain.ResultDAO;
 import ch.jtaf.ui.AbstractViewTest;
 import ch.jtaf.ui.DashboardView;
+import ch.jtaf.usecase.UseCase;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.textfield.TextField;
+import org.jooq.Record5;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+import static ch.jtaf.db.tables.Athlete.ATHLETE;
+import static ch.jtaf.db.tables.Category.CATEGORY;
+import static ch.jtaf.db.tables.Result.RESULT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -18,10 +30,23 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Also exercises UC-084 (Calculate IAAF points) — each entered result triggers point
  * calculation which is asserted alongside the value.
  * <p>
+ * The dashboard button {@code enter-results-1-1} opens competition 6 (series
+ * "Jugendmeisterschaft 2019"), {@code enter-results-2-1} competition 4 (series "CIS
+ * 2019").
+ * <p>
  * See {@code docs/use_cases/uc-080-enter-result.md} and
  * {@code docs/use_cases/uc-084-calculate-iaaf-points.md}.
  */
 class UC080EnterResultTest extends AbstractViewTest {
+
+	@Autowired
+	private AthleteDAO athleteDAO;
+
+	@Autowired
+	private ResultDAO resultDAO;
+
+	@Autowired
+	private EventDAO eventDAO;
 
 	@BeforeEach
 	void login() {
@@ -29,7 +54,16 @@ class UC080EnterResultTest extends AbstractViewTest {
 		navigate(DashboardView.class);
 	}
 
+	@AfterEach
+	void removeCreatedResults() {
+		// The seed contains no results for Ansari in competition 6 nor for Amos in
+		// competition 4; everything found there was created by these tests.
+		deleteResults("Ansari", 6L);
+		deleteResults("Amos", 4L);
+	}
+
 	@Test
+	@UseCase(id = "UC-080")
 	void check_pre_entered_results() {
 		find(Button.class).id("enter-results-1-1").click();
 
@@ -40,10 +74,14 @@ class UC080EnterResultTest extends AbstractViewTest {
 	}
 
 	@Test
+	@UseCase(id = "UC-080", businessRules = { "BR-047", "BR-048" })
 	void enter_new_results() {
 		find(Button.class).id("enter-results-1-1").click();
 
 		test(find(TextField.class).id("filter")).setValue("Ansari");
+		Record5<Long, String, String, String, Long> selected = selectedAthlete();
+		long athleteId = selected.get(ATHLETE.ID);
+		long categoryId = selected.get(CATEGORY.ID);
 
 		test(find(TextField.class).id("result-0")).setValue("12.34");
 		assertThat(find(TextField.class).id("points-0").getValue()).isEqualTo("48");
@@ -53,9 +91,22 @@ class UC080EnterResultTest extends AbstractViewTest {
 
 		test(find(TextField.class).id("result-2")).setValue("23.45");
 		assertThat(find(TextField.class).id("points-2").getValue()).isEqualTo("252");
+
+		// BR-047 auto-save: every value change persisted a RESULT row, BR-048: each row
+		// inherits its position from the iteration index over the category's events
+		var events = eventDAO.findByCategoryIdOrderByPosition(categoryId);
+		String[] expectedResults = { "12.34", "2.11", "23.45" };
+		int[] expectedPoints = { 48, 108, 252 };
+		for (int i = 0; i < expectedResults.length; i++) {
+			var resultRecord = resultDAO.getResults(6L, athleteId, categoryId, events.get(i).getId()).orElseThrow();
+			assertThat(resultRecord.getResult()).isEqualTo(expectedResults[i]);
+			assertThat(resultRecord.getPoints()).isEqualTo(expectedPoints[i]);
+			assertThat(resultRecord.getPosition()).isEqualTo(i);
+		}
 	}
 
 	@Test
+	@UseCase(id = "UC-080")
 	void enter_new_results_incl_long_run() {
 		find(Button.class).id("enter-results-2-1").click();
 
@@ -72,6 +123,101 @@ class UC080EnterResultTest extends AbstractViewTest {
 
 		test(find(TextField.class).id("result-3")).setValue("2.52");
 		assertThat(find(TextField.class).id("points-3").getValue()).isEqualTo("68");
+	}
+
+	@Test
+	@UseCase(id = "UC-080", scenario = "A1: Athlete not yet selected")
+	void grid_and_form_are_empty_before_a_filter_is_typed() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		// Step 2: the athletes grid is initially empty
+		assertThat(test(athletesGrid()).size()).isZero();
+		// A1: the form area below the grid stays empty
+		assertThat(find(TextField.class).withId("result-0").all()).isEmpty();
+	}
+
+	@Test
+	@UseCase(id = "UC-080")
+	void manually_selecting_an_athlete_builds_the_form() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		// Several athletes match, so nothing is auto-selected
+		test(find(TextField.class).id("filter")).setValue("Aebi");
+		Grid<Record5<Long, String, String, String, Long>> grid = athletesGrid();
+		assertThat(test(grid).size()).isEqualTo(3);
+		assertThat(grid.asSingleSelect().getValue()).isNull();
+		assertThat(find(TextField.class).withId("result-0").all()).isEmpty();
+
+		// Step 3: the user selects an athlete
+		test(grid).select(0);
+		assertThat(grid.asSingleSelect().getValue()).isNotNull();
+		assertThat(find(TextField.class).withId("result-0").all()).hasSize(1);
+	}
+
+	@Test
+	@UseCase(id = "UC-080", scenario = "A2: Filter resolves to zero athletes")
+	void filter_without_match_clears_the_form() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		test(find(TextField.class).id("filter")).setValue("Martinelli");
+		assertThat(find(TextField.class).withId("result-0").all()).hasSize(1);
+
+		test(find(TextField.class).id("filter")).setValue("Zzzzzz");
+
+		assertThat(test(athletesGrid()).size()).isZero();
+		assertThat(athletesGrid().asSingleSelect().getValue()).isNull();
+		assertThat(find(TextField.class).withId("result-0").all()).isEmpty();
+	}
+
+	@Test
+	@UseCase(id = "UC-080", scenario = "Failure Postconditions")
+	void invalid_input_shows_notification_and_saves_nothing() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		test(find(TextField.class).id("filter")).setValue("Martinelli");
+		Record5<Long, String, String, String, Long> selected = selectedAthlete();
+		long athleteId = selected.get(ATHLETE.ID);
+		long categoryId = selected.get(CATEGORY.ID);
+		long firstEventId = eventDAO.findByCategoryIdOrderByPosition(categoryId).getFirst().getId();
+
+		test(find(TextField.class).id("result-0")).setValue("12.2.2");
+
+		assertThat(find(Notification.class).all()).isNotEmpty();
+		assertThat(test(find(Notification.class).single()).getText()).isEqualTo("Invalid result");
+		// The points field and the persisted row are unchanged
+		assertThat(find(TextField.class).id("points-0").getValue()).isEqualTo("402");
+		var resultRecord = resultDAO.getResults(6L, athleteId, categoryId, firstEventId).orElseThrow();
+		assertThat(resultRecord.getResult()).isEqualTo("12.12");
+		assertThat(resultRecord.getPoints()).isEqualTo(402);
+	}
+
+	@Test
+	@UseCase(id = "UC-080", businessRules = "BR-049")
+	void points_fields_are_read_only() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		test(find(TextField.class).id("filter")).setValue("Martinelli");
+
+		TextField points = find(TextField.class).id("points-0");
+		assertThat(points.isReadOnly()).isTrue();
+		assertThat(points.isEnabled()).isFalse();
+	}
+
+	@SuppressWarnings("unchecked")
+	private Grid<Record5<Long, String, String, String, Long>> athletesGrid() {
+		return find(Grid.class).all().getFirst();
+	}
+
+	private Record5<Long, String, String, String, Long> selectedAthlete() {
+		Record5<Long, String, String, String, Long> selected = athletesGrid().asSingleSelect().getValue();
+		assertThat(selected).isNotNull();
+		return selected;
+	}
+
+	private void deleteResults(String lastName, long competitionId) {
+		athleteDAO.findAll(ATHLETE.LAST_NAME.eq(lastName))
+			.forEach(athlete -> resultDAO
+				.delete(RESULT.ATHLETE_ID.eq(athlete.getId()).and(RESULT.COMPETITION_ID.eq(competitionId))));
 	}
 
 }

--- a/src/test/java/ch/jtaf/ui/usecase/result/UC083FilterAthletesForResultEntryTest.java
+++ b/src/test/java/ch/jtaf/ui/usecase/result/UC083FilterAthletesForResultEntryTest.java
@@ -1,23 +1,41 @@
 package ch.jtaf.ui.usecase.result;
 
 import ch.jtaf.configuration.security.Role;
+import ch.jtaf.domain.AthleteDAO;
 import ch.jtaf.ui.AbstractViewTest;
 import ch.jtaf.ui.DashboardView;
+import ch.jtaf.usecase.UseCase;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
+import org.jooq.Record5;
+import org.jooq.impl.DSL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
+import static ch.jtaf.db.tables.Athlete.ATHLETE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * UC-083: Filter athletes for result entry.
  * <p>
+ * The dashboard button {@code enter-results-1-1} opens competition 6 (series
+ * "Jugendmeisterschaft 2019"). The seeded athlete Lukas Martinelli (id 140) is enrolled
+ * there; "Aebi" matches three athletes.
+ * <p>
+ * The browser focus of the first result field (BR-053) cannot be observed server-side; it
+ * needs a browser-based (Playwright) test.
+ * <p>
  * See {@code docs/use_cases/uc-083-filter-athletes-for-result-entry.md}.
  */
 class UC083FilterAthletesForResultEntryTest extends AbstractViewTest {
+
+	@Autowired
+	private AthleteDAO athleteDAO;
 
 	@BeforeEach
 	void login() {
@@ -26,13 +44,105 @@ class UC083FilterAthletesForResultEntryTest extends AbstractViewTest {
 	}
 
 	@Test
+	@UseCase(id = "UC-083", businessRules = "BR-052")
 	void search_with_id() {
 		find(Button.class).id("enter-results-1-1").click();
 
 		test(find(TextField.class).id("filter")).setValue("140");
 
+		assertThat(test(athletesGrid()).size()).isEqualTo(1);
 		assertThat(find(TextField.class).withCaption("80 m").single().getValue()).isEqualTo("12.12");
 		assertThat(find(TextField.class).id("points-0").getValue()).isEqualTo("402");
+	}
+
+	@Test
+	@UseCase(id = "UC-083")
+	void filter_field_is_focused_and_reacts_to_every_keystroke() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		TextField filter = find(TextField.class).id("filter");
+		// Step 1: the filter field receives the focus via autofocus
+		assertThat(filter.isAutofocus()).isTrue();
+		// Step 3: the data provider is recomputed on every keystroke
+		assertThat(filter.getValueChangeMode()).isEqualTo(ValueChangeMode.EAGER);
+	}
+
+	@Test
+	@UseCase(id = "UC-083")
+	void name_filter_matches_first_or_last_name_case_insensitively() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		// Step 5: case-insensitive prefix on the first name
+		test(find(TextField.class).id("filter")).setValue("luka");
+		Grid<Record5<Long, String, String, String, Long>> grid = athletesGrid();
+		assertThat(test(grid).size()).isEqualTo(1);
+		assertThat(test(grid).getRow(0).get(ATHLETE.LAST_NAME)).isEqualTo("Martinelli");
+
+		// and on the last name
+		test(find(TextField.class).id("filter")).setValue("aebi");
+		assertThat(test(grid).size()).isEqualTo(3);
+	}
+
+	@Test
+	@UseCase(id = "UC-083", businessRules = "BR-053")
+	void single_match_auto_selects_the_athlete_and_opens_the_form() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		test(find(TextField.class).id("filter")).setValue("140");
+
+		Grid<Record5<Long, String, String, String, Long>> grid = athletesGrid();
+		assertThat(test(grid).size()).isEqualTo(1);
+		assertThat(grid.asSingleSelect().getValue()).isNotNull();
+		assertThat(find(TextField.class).withId("result-0").all()).hasSize(1);
+	}
+
+	@Test
+	@UseCase(id = "UC-083", businessRules = "BR-053")
+	void multiple_matches_do_not_auto_select() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		test(find(TextField.class).id("filter")).setValue("Aebi");
+
+		Grid<Record5<Long, String, String, String, Long>> grid = athletesGrid();
+		assertThat(test(grid).size()).isEqualTo(3);
+		assertThat(grid.asSingleSelect().getValue()).isNull();
+		assertThat(find(TextField.class).withId("result-0").all()).isEmpty();
+	}
+
+	@Test
+	@UseCase(id = "UC-083", businessRules = "BR-052")
+	void unknown_number_never_falls_back_to_name_search() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		test(find(TextField.class).id("filter")).setValue("888888");
+
+		assertThat(test(athletesGrid()).size()).isZero();
+	}
+
+	@Test
+	@UseCase(id = "UC-083", scenario = "A1: Empty filter")
+	void clearing_the_filter_lists_all_athletes_and_keeps_the_form() {
+		find(Button.class).id("enter-results-1-1").click();
+
+		// The grid is empty before any filter has been typed
+		Grid<Record5<Long, String, String, String, Long>> grid = athletesGrid();
+		assertThat(test(grid).size()).isZero();
+
+		test(find(TextField.class).id("filter")).setValue("140");
+		assertThat(find(TextField.class).withId("result-0").all()).hasSize(1);
+
+		// Clearing the filter back to "" lists all athletes of the competition
+		test(find(TextField.class).id("filter")).setValue("");
+		assertThat(test(grid).size()).isEqualTo(athleteDAO.countAthletes(6L, DSL.noCondition()));
+
+		// and the form below the grid is not cleared
+		assertThat(grid.asSingleSelect().getValue()).isNotNull();
+		assertThat(find(TextField.class).withId("result-0").all()).hasSize(1);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Grid<Record5<Long, String, String, String, Long>> athletesGrid() {
+		return find(Grid.class).all().getFirst();
 	}
 
 }

--- a/src/test/java/ch/jtaf/ui/view/ProtectedViewTest.java
+++ b/src/test/java/ch/jtaf/ui/view/ProtectedViewTest.java
@@ -3,6 +3,7 @@ package ch.jtaf.ui.view;
 import ch.jtaf.configuration.security.Role;
 import ch.jtaf.ui.AbstractViewTest;
 import ch.jtaf.ui.ClubsView;
+import ch.jtaf.usecase.UseCase;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.H1;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ProtectedViewTest extends AbstractViewTest {
 
 	@Test
+	@UseCase(id = "UC-003", businessRules = "BR-006")
 	void user_without_organization() {
 		// This user has no organization
 		login("susan.miller@mail.com", "pass", List.of(Role.ADMIN));

--- a/src/test/resources/db/migration/V9999__Data.sql
+++ b/src/test/resources/db/migration/V9999__Data.sql
@@ -579,7 +579,8 @@ INSERT INTO category_athlete (category_id, athlete_id) VALUES(25, 204);
 INSERT INTO category_athlete (category_id, athlete_id) VALUES(35, 205);
 INSERT INTO category_athlete (category_id, athlete_id) VALUES(36, 206);
 INSERT INTO category_athlete (category_id, athlete_id) VALUES(33, 207);
-INSERT INTO category_athlete (category_id, athlete_id) VALUES(35, 208);
+-- Removed orphan enrolment (category 35, athlete 208): athlete 208 does not exist;
+-- the row slipped in because FK checks are disabled during seeding.
 INSERT INTO category_athlete (category_id, athlete_id) VALUES(29, 209);
 INSERT INTO category_athlete (category_id, athlete_id) VALUES(29, 210);
 INSERT INTO category_athlete (category_id, athlete_id) VALUES(34, 211);
@@ -2298,6 +2299,53 @@ INSERT INTO user_group (user_id, group_id) VALUES(2, 2);
 
 INSERT INTO organization_user (organization_id, user_id) VALUES (1, 2);
 INSERT INTO organization_user (organization_id, user_id) VALUES (2, 2);
+
+-- Specification-coverage fixtures (docs/gap_analysis.md): an organization that is not
+-- linked to any seeded user, holding hidden series that exercise the ranking edge cases:
+-- a series without competitions, a series with a competition but no results, a series
+-- with a DNF athlete and an athlete missing a competition, and overlapping categories.
+
+INSERT INTO organization (id, organization_key, name, owner) VALUES(3, 'TST', 'Test Fixtures', 'fixtures@jtaf.ch');
+ALTER SEQUENCE organization_seq RESTART WITH 4;
+
+INSERT INTO series (id, name, logo, hidden, locked, organization_id) VALUES(5, 'Fixture No Competitions', NULL, true, false, 3);
+INSERT INTO series (id, name, logo, hidden, locked, organization_id) VALUES(6, 'Fixture No Results', NULL, true, false, 3);
+INSERT INTO series (id, name, logo, hidden, locked, organization_id) VALUES(7, 'Fixture Ranking Rules', NULL, true, false, 3);
+INSERT INTO series (id, name, logo, hidden, locked, organization_id) VALUES(8, 'Fixture Overlapping Categories', NULL, true, false, 3);
+ALTER SEQUENCE series_seq RESTART WITH 9;
+
+INSERT INTO competition (id, name, competition_date, always_first_three_medals, medal_percentage, locked, series_id) VALUES(7, 'Fixture No Results Meeting', '2020-05-02', true, 0, false, 6);
+INSERT INTO competition (id, name, competition_date, always_first_three_medals, medal_percentage, locked, series_id) VALUES(8, 'Fixture Ranking Meeting 1', '2020-05-09', true, 0, false, 7);
+INSERT INTO competition (id, name, competition_date, always_first_three_medals, medal_percentage, locked, series_id) VALUES(9, 'Fixture Ranking Meeting 2', '2020-05-16', true, 0, false, 7);
+ALTER SEQUENCE competition_seq RESTART WITH 10;
+
+INSERT INTO category (id, abbreviation, name, gender, year_from, year_to, series_id) VALUES(49, 'M', 'Maenner', 'M', 1900, 9999, 6);
+INSERT INTO category (id, abbreviation, name, gender, year_from, year_to, series_id) VALUES(50, 'M', 'Maenner', 'M', 1900, 9999, 7);
+INSERT INTO category (id, abbreviation, name, gender, year_from, year_to, series_id) VALUES(51, 'M', 'Maenner', 'M', 1900, 9999, 8);
+INSERT INTO category (id, abbreviation, name, gender, year_from, year_to, series_id) VALUES(52, 'M2', 'Maenner 2', 'M', 1950, 2050, 8);
+ALTER SEQUENCE category_seq RESTART WITH 53;
+
+INSERT INTO category_event (category_id, event_id, position) VALUES(49, 1, 0);
+INSERT INTO category_event (category_id, event_id, position) VALUES(50, 1, 0);
+
+INSERT INTO athlete (id, first_name, last_name, gender, year_of_birth, club_id, organization_id) VALUES(234, 'Fabio', 'Fixturecomplete', 'M', 2000, NULL, 3);
+INSERT INTO athlete (id, first_name, last_name, gender, year_of_birth, club_id, organization_id) VALUES(235, 'Dario', 'Fixturednf', 'M', 2001, NULL, 3);
+INSERT INTO athlete (id, first_name, last_name, gender, year_of_birth, club_id, organization_id) VALUES(236, 'Ivo', 'Fixtureincomplete', 'M', 2002, NULL, 3);
+INSERT INTO athlete (id, first_name, last_name, gender, year_of_birth, club_id, organization_id) VALUES(237, 'Nico', 'Fixturenoresult', 'M', 2003, NULL, 3);
+INSERT INTO athlete (id, first_name, last_name, gender, year_of_birth, club_id, organization_id) VALUES(238, 'Olaf', 'Fixtureoverlap', 'M', 2004, NULL, 3);
+ALTER SEQUENCE athlete_seq RESTART WITH 239;
+
+INSERT INTO category_athlete (category_id, athlete_id) VALUES(49, 237);
+INSERT INTO category_athlete (category_id, athlete_id) VALUES(50, 234);
+INSERT INTO category_athlete (category_id, athlete_id, dnf) VALUES(50, 235, true);
+INSERT INTO category_athlete (category_id, athlete_id) VALUES(50, 236);
+
+INSERT INTO result (id, position, result, points, athlete_id, category_id, competition_id, event_id) VALUES(1487, 0, '12.00', 500, 234, 50, 8, 1);
+INSERT INTO result (id, position, result, points, athlete_id, category_id, competition_id, event_id) VALUES(1488, 0, '12.10', 480, 234, 50, 9, 1);
+INSERT INTO result (id, position, result, points, athlete_id, category_id, competition_id, event_id) VALUES(1489, 0, '12.20', 460, 235, 50, 8, 1);
+INSERT INTO result (id, position, result, points, athlete_id, category_id, competition_id, event_id) VALUES(1490, 0, '12.30', 440, 235, 50, 9, 1);
+INSERT INTO result (id, position, result, points, athlete_id, category_id, competition_id, event_id) VALUES(1491, 0, '12.40', 420, 236, 50, 8, 1);
+ALTER SEQUENCE result_seq RESTART WITH 1492;
 
 SET session_replication_role = 'origin';
 COMMIT;


### PR DESCRIPTION
## Summary

Closes every test gap identified in [`docs/gap_analysis.md`](docs/gap_analysis.md) for the five audited use cases (UC-003, UC-072, UC-080, UC-083, UC-091), plus the cross-cutting recommendations. Along the way two real defects were found and fixed.

### Test gaps closed

- **UC-003 Sign in** — fixed the inverted `login_with_unknown_user` assertion; added tests for the `?error` localized error state (A1), form labels (Step 2), drawer link visibility (Step 6), and BR-006 (anonymous bounce, USER role). New `UC003SignInAuthenticationTest` exercises the real Spring Security chain via MockMvc: BCrypt verification, JWT cookies (`jwt.headerAndPayload`/`jwt.signature`), redirects, and the unconfirmed-user rejection (A2/BR-005).
- **UC-072 Assign athlete to series** — main path now asserts the resolved category, `dnf` default, dialog closure and `countAthletesBySeriesId`; new tests for A1–A4, BR-045 and Post-F-1; cleanup moved to `@AfterEach`.
- **UC-080 Enter result** — persistence read-back of value/points/`position` (BR-047/BR-048/Post-S-1), invalid input notification with nothing saved (Post-F-1), empty grid/form (Step 2/A1), manual selection (Step 3), zero-match clearing (A2), read-only points (BR-049).
- **UC-083 Filter athletes** — autofocus (Step 1), `EAGER` mode (Step 3), case-insensitive first/last-name prefixes (Step 5), auto-selection rules (BR-052/BR-053), empty-filter flow (A1).
- **UC-091 Download series ranking** — downloads now assert non-empty `%PDF` bytes and the `_blank` target; anonymous download (BR-060); eligibility rules (BR-059); no-competitions, no-results, unknown-series and swallowed-error 0-byte paths.

### Defects found and fixed

1. **`CategoryAthleteId` component order** — `JooqDAO#findById` maps the id record positionally onto the primary key `(athlete_id, category_id)`; the record was declared `(categoryId, athleteId)`, so the DNF checkbox in `ResultCapturingView` never pre-populated from the database.
2. **Orphan seed row** — `V9999__Data.sql` contained an enrolment for a nonexistent athlete (FK checks are disabled during seeding); removed.

### Cross-cutting

- New canonical `@UseCase(id, scenario, businessRules)` annotation (`ch.jtaf.usecase`), applied to the use case tests and retrofitted to `UserDetailsServiceImplTest`, `SeriesRankingServiceTest` and `ProtectedViewTest`.
- `UC-XXX` traceability Javadoc on the views, dialogs, DAOs and services realizing the audited use cases.
- Test seed extended with hidden fixture series 5–8 in an isolated organization (series without competitions, competitions without results, DNF + incomplete athletes, overlapping categories) — invisible to the dashboard and seeded users, so no existing test changed behavior.
- UC-072 A3 spec wording aligned with the code (`fetchOptionalInto`).

Deliberately unchanged: spec `**Status:**` lines (to be moved by `/coverage-check`), the Playwright-only browser-focus assertion for BR-053, and the remaining 40 unaudited use cases (§4.3 follow-up).

## Test plan

- [x] `./mvnw test` — 159 tests, 0 failures, 0 errors
- [x] `./mvnw spring-javaformat:apply` + ErrorProne `-Werror` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)